### PR TITLE
Fix JavaScript error - use correct function name getDateKey

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -470,7 +470,7 @@ function renderRosterPanel() {
     workers.forEach(w => {
         let scheduledDays = 0;
         dates.forEach(date => {
-            const dateKey = formatDate(date);
+            const dateKey = getDateKey(date);
             // Check if worker is scheduled on any job this day
             const isScheduled = Object.keys(dailySchedule).some(key => {
                 if (key.includes(dateKey)) {


### PR DESCRIPTION
The renderRosterPanel function was calling formatDate() which doesn't exist. Changed to getDateKey() which is the correct function for getting YYYY-MM-DD format date strings.

This was causing the entire page to fail to render.

https://claude.ai/code/session_01BPeAQAFYCgSgLh8dKSanjx