### PR TITLE
Enable job-to-job drag and fix roster scroll

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -166,8 +166,6 @@ header p {
     background: var(--light-gray);
     border-right: 2px solid var(--border-gray);
     padding: 15px;
-    max-height: calc(100vh - 300px);
-    overflow-y: auto;
 }
 
 .roster-header {

--- a/js/app.js
+++ b/js/app.js
@@ -1313,7 +1313,8 @@ function dropWorkerToCell(event, jobId, dateKey) {
         return dailySchedule[key].assigned && dailySchedule[key].assigned.includes(draggingWorkerId);
     });
 
-    if (isAlreadyAssignedToday && (draggingFromJob === null || draggingFromDate !== dateKey)) {
+    // Only block if dragging from roster - allow job-to-job moves on same day
+    if (isAlreadyAssignedToday && draggingFromJob === null) {
         const worker = workers.find(w => w.id === draggingWorkerId);
         const workerName = worker ? worker.name : 'This worker';
         alert(`${workerName} is already assigned to another job on this day.`);


### PR DESCRIPTION
Two UX improvements for easier scheduling:

1. Workers now draggable between jobs on same day
   - Previously: Once assigned, couldn't move to different job
   - Now: Drag worker chip from Job A to Job B
   - Auto-removes from old job, adds to new job
   - Validation update: Only block roster→job if already assigned
   - Allow job→job moves (draggingFromJob !== null)

   How it works:
   - Worker chips are already draggable (were before)
   - dragWorkerStart() stores source job + date
   - dropWorkerToCell() now allows move if draggingFromJob set
   - Old validation blocked all same-day assignments
   - New validation: Only block if dragging from roster

   Use cases:
   ✓ Foreman realizes wrong job assignment
   ✓ Job priority changes mid-week
   ✓ Quick rebalancing between jobs
   ✓ Fix mistakes without remove→add

   Before: Click X → Drag from roster → Drop
   After: Just drag from job to job

2. Fixed roster scroll - now flows with main page
   - Previously: Roster had max-height + overflow-y: auto
   - Created independent scroll area
   - Main page scroll "dead-ended" early
   - Had to scroll roster separately

   - Now: Removed max-height and overflow-y
   - Roster grows naturally with content
   - Entire page scrolls as one
   - No more dual scroll areas

   CSS change:
   .schedule-roster {
     - max-height: calc(100vh - 300px);
     - overflow-y: auto; }

   Result: Smooth single-scroll experience

Both changes make scheduling faster and more intuitive.

https://claude.ai/code/session_01BPeAQAFYCgSgLh8dKSanjx