### PR TITLE
Implement bottom tray roster with day-based filtering

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -211,93 +211,109 @@ header p {
     display: flex;
     gap: 0;
     overflow-x: auto;
+    padding-bottom: 200px; /* Space for bottom tray */
 }
 
-/* Team Roster (Left Panel) - STICKY */
-.schedule-roster {
-    flex-shrink: 0;
-    width: 200px;
+/* Bottom Roster Tray */
+.roster-tray {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: white;
+    border-top: 3px solid var(--primary-blue);
+    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.15);
+    z-index: 100;
+    transition: transform 0.3s ease;
+    max-height: 220px;
+}
+
+.roster-tray.collapsed {
+    transform: translateY(calc(100% - 52px));
+}
+
+.roster-tray-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 20px;
     background: var(--light-gray);
-    border-right: 2px solid var(--border-gray);
-    padding: 15px;
-    position: sticky;
-    top: 0;
-    align-self: flex-start;
-    max-height: 100vh;
-    overflow-y: auto;
-    overflow-x: hidden;
-    transition: width 0.3s ease, padding 0.3s ease;
-    position: relative;
+    border-bottom: 2px solid var(--border-gray);
 }
 
-.schedule-roster.collapsed {
-    width: 40px;
-    padding: 15px 8px;
+.roster-tray-title {
+    display: flex;
+    align-items: center;
+    gap: 12px;
 }
 
-.roster-collapse-btn {
-    position: absolute;
-    right: 8px;
-    top: 15px;
-    width: 28px;
-    height: 28px;
+.roster-tray-title h3 {
+    font-size: 1em;
+    color: var(--text-dark);
+    margin: 0;
+}
+
+.active-day-label {
+    font-size: 0.85em;
+    color: #666;
+    font-weight: normal;
+}
+
+.active-day-label.active {
+    color: var(--primary-blue);
+    font-weight: 600;
+}
+
+.roster-tray-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.roster-tray-actions select {
+    padding: 6px 10px;
+    border: 2px solid var(--border-gray);
+    border-radius: 6px;
+    font-size: 0.85em;
+}
+
+.roster-tray-toggle {
+    width: 32px;
+    height: 32px;
     background: white;
     border: 2px solid var(--border-gray);
     border-radius: 4px;
     cursor: pointer;
-    font-size: 18px;
-    font-weight: bold;
+    font-size: 16px;
     color: var(--text-dark);
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 10;
     transition: all 0.2s ease;
 }
 
-.roster-collapse-btn:hover {
+.roster-tray-toggle:hover {
     background: var(--primary-blue);
     color: white;
     border-color: var(--primary-blue);
 }
 
-.schedule-roster.collapsed .roster-collapse-btn {
-    right: 6px;
+.roster-tray.collapsed .roster-tray-toggle {
     transform: rotate(180deg);
 }
 
-.roster-content {
-    transition: opacity 0.3s ease;
-}
-
-.schedule-roster.collapsed .roster-content {
-    opacity: 0;
-    pointer-events: none;
-    display: none;
-}
-
-.roster-header {
-    margin-bottom: 15px;
-}
-
-.roster-header h3 {
-    font-size: 1.1em;
-    color: var(--text-dark);
-    margin-bottom: 10px;
-}
-
-.roster-header select {
-    width: 100%;
-    padding: 8px;
-    border: 2px solid var(--border-gray);
-    border-radius: 6px;
-    font-size: 0.9em;
+.roster-tray-content {
+    padding: 15px 20px;
+    overflow-y: auto;
+    max-height: 150px;
 }
 
 .roster-workers {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    flex-wrap: wrap;
     gap: 8px;
+    align-items: flex-start;
 }
 
 .roster-empty {
@@ -393,6 +409,31 @@ header p {
     background: #e3f2fd;
     border-color: #2196f3;
     box-shadow: 0 0 0 2px #2196f3;
+}
+
+/* Worker Availability States (for active day filtering) */
+.worker-chip.worker-available {
+    opacity: 1;
+    border-width: 2px;
+}
+
+.worker-chip.worker-assigned {
+    opacity: 0.4;
+    filter: grayscale(50%);
+}
+
+.worker-chip.worker-on-vacation {
+    display: none;
+}
+
+.col-day.day-active {
+    background: var(--primary-blue);
+    color: white;
+    cursor: pointer;
+}
+
+.col-day.day-active:hover {
+    background: var(--light-blue);
 }
 
 /* Worker Availability Tracking */

--- a/index.html
+++ b/index.html
@@ -62,27 +62,33 @@
                     <button class="schedule-nav-btn" onclick="navigateNext()">Next &#8250;</button>
                 </div>
                 <div class="schedule-body">
-                    <!-- Team Roster -->
-                    <div class="schedule-roster" id="scheduleRoster"
-                         ondragover="event.preventDefault(); this.classList.add('roster-drag-over')"
-                         ondragleave="this.classList.remove('roster-drag-over')"
-                         ondrop="dropWorkerToRoster(event)">
-                        <button class="roster-collapse-btn" id="rosterCollapseBtn" onclick="toggleRoster()" title="Collapse roster">&#8249;</button>
-                        <div class="roster-content" id="rosterContent">
-                            <div class="roster-header">
-                                <h3>Team Roster</h3>
-                                <select id="rosterDivisionFilter" onchange="renderSchedule()">
-                                    <option value="all">All</option>
-                                    <option value="commercial">Commercial</option>
-                                    <option value="residential">Residential</option>
-                                </select>
-                            </div>
-                            <div class="roster-workers" id="rosterWorkers"></div>
-                        </div>
-                    </div>
                     <!-- Schedule Grid -->
                     <div class="schedule-grid-container">
                         <div id="scheduleGrid"></div>
+                    </div>
+                </div>
+
+                <!-- Bottom Roster Tray -->
+                <div class="roster-tray" id="rosterTray"
+                     ondragover="event.preventDefault(); this.classList.add('roster-drag-over')"
+                     ondragleave="this.classList.remove('roster-drag-over')"
+                     ondrop="dropWorkerToRoster(event)">
+                    <div class="roster-tray-header">
+                        <div class="roster-tray-title">
+                            <h3>Available Workers</h3>
+                            <span class="active-day-label" id="activeDayLabel">Click a day to filter</span>
+                        </div>
+                        <div class="roster-tray-actions">
+                            <select id="rosterDivisionFilter" onchange="renderSchedule()">
+                                <option value="all">All</option>
+                                <option value="commercial">Commercial</option>
+                                <option value="residential">Residential</option>
+                            </select>
+                            <button class="roster-tray-toggle" id="rosterTrayToggle" onclick="toggleRosterTray()" title="Collapse roster">▼</button>
+                        </div>
+                    </div>
+                    <div class="roster-tray-content" id="rosterTrayContent">
+                        <div class="roster-workers" id="rosterWorkers"></div>
                     </div>
                 </div>
             </div>

--- a/js/app.js
+++ b/js/app.js
@@ -35,6 +35,7 @@ let showWeeklyOverview = false; // Show print-style worker-centric view
 let showUtilization = true; // Show worker utilization panel
 let showSuggestions = true; // Show smart suggestions panel
 let selectedWorkerId = null; // For click-to-assign mode
+let activeDateKey = null; // For day-based roster filtering
 
 // ============================================================================
 // Modal Functions
@@ -635,19 +636,50 @@ function renderMobileSchedule() {
 }
 
 /**
- * Toggle roster panel collapse/expand
+ * Toggle roster tray collapse/expand
  */
-function toggleRoster() {
-    const roster = document.getElementById('scheduleRoster');
-    const btn = document.getElementById('rosterCollapseBtn');
-    if (!roster || !btn) return;
+function toggleRosterTray() {
+    const tray = document.getElementById('rosterTray');
+    const btn = document.getElementById('rosterTrayToggle');
+    if (!tray || !btn) return;
 
-    roster.classList.toggle('collapsed');
+    tray.classList.toggle('collapsed');
 
-    if (roster.classList.contains('collapsed')) {
+    if (tray.classList.contains('collapsed')) {
         btn.title = 'Expand roster';
     } else {
         btn.title = 'Collapse roster';
+    }
+}
+
+/**
+ * Activate a day for roster filtering
+ */
+function activateDay(dateKey, dayElement) {
+    // Toggle: if clicking same day, deactivate
+    if (activeDateKey === dateKey) {
+        activeDateKey = null;
+    } else {
+        activeDateKey = dateKey;
+    }
+
+    // Update UI
+    renderSchedule();
+
+    // Update active day label
+    const label = document.getElementById('activeDayLabel');
+    if (label) {
+        if (activeDateKey) {
+            const date = new Date(activeDateKey.replace(/_/g, '/'));
+            const dayNames = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+            const dayName = dayNames[date.getDay()];
+            const dateStr = `${date.getMonth() + 1}/${date.getDate()}`;
+            label.textContent = `${dayName} ${dateStr}`;
+            label.classList.add('active');
+        } else {
+            label.textContent = 'Click a day to filter';
+            label.classList.remove('active');
+        }
     }
 }
 
@@ -721,13 +753,36 @@ function renderRosterPanel() {
         const availableDays = totalDays - scheduledDays;
         const isSelected = selectedWorkerId === w.id;
 
+        // Determine availability state for active day
+        let availabilityClass = '';
+        let availabilityStatus = '';
+        if (activeDateKey) {
+            // Check if on vacation
+            const vacKey = `${w.id}_${activeDateKey}`;
+            if (vacationSchedule[vacKey]) {
+                availabilityClass = 'worker-on-vacation';
+                availabilityStatus = ' (On vacation)';
+            } else {
+                // Check if already assigned
+                const isAssigned = Object.keys(dailySchedule).some(key => {
+                    if (key.endsWith(`_${activeDateKey}`)) {
+                        const slot = dailySchedule[key];
+                        return slot && slot.assigned && slot.assigned.includes(w.id);
+                    }
+                    return false;
+                });
+                availabilityClass = isAssigned ? 'worker-assigned' : 'worker-available';
+                availabilityStatus = isAssigned ? ' (Already assigned)' : ' (Available)';
+            }
+        }
+
         return `
-        <div class="worker-chip worker-chip-compact worker-chip-${w.role} ${isSelected ? 'worker-selected' : ''}"
+        <div class="worker-chip worker-chip-compact worker-chip-${w.role} ${isSelected ? 'worker-selected' : ''} ${availabilityClass}"
              data-worker-id="${w.id}"
              draggable="true"
              ondragstart="dragWorkerStart(event, ${w.id}, null, null)"
              onclick="toggleWorkerSelection(${w.id})"
-             title="${w.name} — ${w.role}${w.isForeman ? ' (Foreman)' : ''}\n${scheduledDays} days scheduled, ${availableDays} available\nClick to select for quick assignment">
+             title="${w.name} — ${w.role}${w.isForeman ? ' (Foreman)' : ''}${availabilityStatus}\n${scheduledDays} days scheduled, ${availableDays} available\nClick to select for quick assignment">
             <span class="chip-name">${w.name}</span>
             <span class="chip-role">${w.role}${w.isForeman ? ' ★' : ''}</span>
         </div>
@@ -796,11 +851,13 @@ function renderScheduleGrid(dates) {
     html += `</tr><tr class="day-headers">
                 <th class="col-job"></th>`;
 
-    // Day headers (18 columns = 3 weeks × 6 days) with dates
+    // Day headers (18 columns = 3 weeks × 6 days) with dates - clickable for filtering
     dates.forEach(date => {
         const dayName = dayNames[date.getDay() === 0 ? 6 : date.getDay() - 1];
         const dateStr = `${date.getMonth() + 1}/${date.getDate()}`;
-        html += `<th class="col-day">${dayName}<br><small>${dateStr}</small></th>`;
+        const dateKey = getDateKey(date);
+        const activeClass = activeDateKey === dateKey ? 'day-active' : '';
+        html += `<th class="col-day ${activeClass}" onclick="activateDay('${dateKey}', this)" style="cursor: pointer;" title="Click to filter available workers">${dayName}<br><small>${dateStr}</small></th>`;
     });
 
     html += `</tr></thead><tbody>`;


### PR DESCRIPTION
- Moved roster from left sidebar to fixed bottom tray (collapsible)
- Added day header click to activate day-based filtering
- Roster now shows worker availability for active day:
  - Bright: available workers
  - Dimmed (40% opacity, grayscale): already assigned that day
  - Hidden: on vacation that day
- Active day highlighted in blue in header
- Active day label shows in roster header (e.g., "Mon 3/15")
- Bottom tray provides 'who's left to assign' view without cognitive load
- Existing drag-and-drop and click-to-assign workflows unchanged
- Schedule body gets padding-bottom to prevent tray overlap

Solves the problem: "hard to tell what guys are left to assign on any given day"

https://claude.ai/code/session_01BPeAQAFYCgSgLh8dKSanjx