### PR TITLE
Move roster tray from bottom to left side (floating)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -211,40 +211,43 @@ header p {
     display: flex;
     gap: 0;
     overflow-x: auto;
-    padding-bottom: 200px; /* Space for bottom tray */
+    padding-left: 280px; /* Space for left tray */
 }
 
-/* Bottom Roster Tray */
+/* Left Roster Tray (Floating) */
 .roster-tray {
     position: fixed;
-    bottom: 0;
     left: 0;
-    right: 0;
+    top: 120px; /* Below header */
+    bottom: 0;
+    width: 260px;
     background: white;
-    border-top: 3px solid var(--primary-blue);
-    box-shadow: 0 -4px 12px rgba(0, 0, 0, 0.15);
+    border-right: 3px solid var(--primary-blue);
+    box-shadow: 4px 0 12px rgba(0, 0, 0, 0.15);
     z-index: 100;
     transition: transform 0.3s ease;
-    max-height: 220px;
+    display: flex;
+    flex-direction: column;
 }
 
 .roster-tray.collapsed {
-    transform: translateY(calc(100% - 52px));
+    transform: translateX(calc(-100% + 50px));
 }
 
 .roster-tray-header {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 12px 20px;
+    flex-direction: column;
+    gap: 10px;
+    padding: 15px;
     background: var(--light-gray);
     border-bottom: 2px solid var(--border-gray);
+    flex-shrink: 0;
 }
 
 .roster-tray-title {
     display: flex;
-    align-items: center;
-    gap: 12px;
+    flex-direction: column;
+    gap: 4px;
 }
 
 .roster-tray-title h3 {
@@ -267,10 +270,11 @@ header p {
 .roster-tray-actions {
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 10px;
 }
 
 .roster-tray-actions select {
+    flex: 1;
     padding: 6px 10px;
     border: 2px solid var(--border-gray);
     border-radius: 6px;
@@ -290,6 +294,7 @@ header p {
     align-items: center;
     justify-content: center;
     transition: all 0.2s ease;
+    flex-shrink: 0;
 }
 
 .roster-tray-toggle:hover {
@@ -303,17 +308,15 @@ header p {
 }
 
 .roster-tray-content {
-    padding: 15px 20px;
+    padding: 15px;
     overflow-y: auto;
-    max-height: 150px;
+    flex: 1;
 }
 
 .roster-workers {
     display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
+    flex-direction: column;
     gap: 8px;
-    align-items: flex-start;
 }
 
 .roster-empty {

--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
                                 <option value="commercial">Commercial</option>
                                 <option value="residential">Residential</option>
                             </select>
-                            <button class="roster-tray-toggle" id="rosterTrayToggle" onclick="toggleRosterTray()" title="Collapse roster">▼</button>
+                            <button class="roster-tray-toggle" id="rosterTrayToggle" onclick="toggleRosterTray()" title="Collapse roster">◀</button>
                         </div>
                     </div>
                     <div class="roster-tray-content" id="rosterTrayContent">


### PR DESCRIPTION
- Changed roster tray from fixed bottom to fixed left side
- Positioned at left edge, below header (top: 120px)
- Width: 260px with vertical worker layout (column)
- Collapsed state slides left, leaving 50px tab visible
- Updated toggle button icon: ▼ → ◀
- Schedule body now has padding-left instead of padding-bottom
- Same day-based filtering functionality preserved
- Workers still show availability states (bright/dimmed/hidden)

Maintains all filtering logic, just repositioned to left side.

https://claude.ai/code/session_01BPeAQAFYCgSgLh8dKSanjx