### PR TITLE
Fix staffing status: use slot.demand instead of slot.manpower

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -630,8 +630,8 @@ function calculateJobStaffingStatus(jobId) {
         if (!slot) return;
 
         // Baseline: generic manpower (treated as journeymen)
-        if (slot.manpower) {
-            baselineJMDays += slot.manpower;
+        if (slot.demand) {
+            baselineJMDays += slot.demand;
         }
 
         // Actual: assigned workers with role weighting


### PR DESCRIPTION
The codebase stores generic manpower in slot.demand, not slot.manpower. This was preventing staffing status indicators from displaying.

https://claude.ai/code/session_01BPeAQAFYCgSgLh8dKSanjx