### PR TITLE
Fix roster sidebar layout and add desktop JobTread controls

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -212,6 +212,11 @@ header p {
     gap: 0;
     overflow-x: auto;
     padding-left: 280px; /* Space for left tray */
+    transition: padding-left 0.3s ease;
+}
+
+.schedule-body.roster-collapsed {
+    padding-left: 0;
 }
 
 /* Left Roster Tray (Floating) */
@@ -612,6 +617,43 @@ header p {
 .col-day {
     min-width: 70px;
     font-size: 0.8em;
+    position: relative;
+}
+
+/* JobTread action icons in day headers */
+.day-jobtread-actions {
+    display: flex;
+    gap: 4px;
+    justify-content: center;
+    margin-top: 4px;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.col-day:hover .day-jobtread-actions {
+    opacity: 1;
+}
+
+.jobtread-icon {
+    font-size: 12px;
+    cursor: pointer;
+    padding: 2px 4px;
+    border-radius: 3px;
+    transition: all 0.2s ease;
+    display: inline-block;
+}
+
+.jobtread-icon:hover {
+    transform: scale(1.2);
+    background: rgba(255, 255, 255, 0.2);
+}
+
+.jobtread-push:hover {
+    background: rgba(76, 175, 80, 0.3);
+}
+
+.jobtread-delete:hover {
+    background: rgba(244, 67, 54, 0.3);
 }
 
 .col-job-name {

--- a/js/app.js
+++ b/js/app.js
@@ -815,9 +815,15 @@ function renderMobileSchedule() {
 function toggleRosterTray() {
     const tray = document.getElementById('rosterTray');
     const btn = document.getElementById('rosterTrayToggle');
+    const scheduleBody = document.querySelector('.schedule-body');
     if (!tray || !btn) return;
 
     tray.classList.toggle('collapsed');
+
+    // Remove padding from schedule body when roster is collapsed
+    if (scheduleBody) {
+        scheduleBody.classList.toggle('roster-collapsed');
+    }
 
     if (tray.classList.contains('collapsed')) {
         btn.title = 'Expand roster';
@@ -1031,7 +1037,13 @@ function renderScheduleGrid(dates) {
         const dateStr = `${date.getMonth() + 1}/${date.getDate()}`;
         const dateKey = getDateKey(date);
         const activeClass = activeDateKey === dateKey ? 'day-active' : '';
-        html += `<th class="col-day ${activeClass}" onclick="activateDay('${dateKey}', this)" style="cursor: pointer;" title="Click to filter available workers">${dayName}<br><small>${dateStr}</small></th>`;
+        html += `<th class="col-day ${activeClass}" onclick="activateDay('${dateKey}', this)" style="cursor: pointer;" title="Click to filter available workers">
+            ${dayName}<br><small>${dateStr}</small>
+            <div class="day-jobtread-actions">
+                <span class="jobtread-icon jobtread-push" onclick="event.stopPropagation(); pushDayToJobTread('${dateKey}')" title="Push to JobTread">📤</span>
+                <span class="jobtread-icon jobtread-delete" onclick="event.stopPropagation(); deleteDayFromJobTread('${dateKey}')" title="Delete from JobTread">🗑️</span>
+            </div>
+        </th>`;
     });
 
     html += `</tr></thead><tbody>`;


### PR DESCRIPTION
Changes:
1. Fixed roster sidebar white space when collapsed
   - Schedule grid now expands to full width when roster collapsed
   - Added smooth transition animation

2. Added JobTread push/delete to desktop view
   - Each day header shows action icons on hover
   - Push (📤) and Delete (🗑️) icons for each day
   - Icons prevent event bubbling to avoid day filter activation

https://claude.ai/code/session_01BPeAQAFYCgSgLh8dKSanjx