### PR TITLE
Add Excel-like keyboard navigation and improve UX

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -668,38 +668,29 @@ header p {
     background: white;
     border: 1px solid var(--border-gray);
     border-radius: 4px;
-    padding: 4px 6px;
-    cursor: grab;
+    padding: 4px 8px;
+    cursor: pointer;
     display: inline-flex;
     align-items: center;
     gap: 4px;
     margin: 2px;
     font-size: 0.75em;
+    transition: all 0.2s ease;
+}
+
+.worker-chip-mini:hover {
+    background: #ffebee;
+    border-color: #dc3545;
+    transform: translateY(-1px);
 }
 
 .chip-name-mini {
     font-weight: 600;
 }
 
+/* Chip remove button - hidden, chip itself is clickable now */
 .chip-remove {
-    background: #dc3545;
-    color: white;
-    border: none;
-    border-radius: 3px;
-    width: 16px;
-    height: 16px;
-    cursor: pointer;
-    padding: 0;
-    margin: 0;
-    font-size: 12px;
-    line-height: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.chip-remove:hover {
-    background: #c82333;
+    display: none;
 }
 
 /* Schedule Grid Container */
@@ -770,6 +761,18 @@ header p {
     min-width: 70px;
     font-size: 0.8em;
     position: relative;
+    transition: background 0.3s ease;
+}
+
+/* Day header when fully staffed */
+.col-day.day-fully-staffed {
+    background: linear-gradient(135deg, #4CAF50 0%, #66BB6A 100%);
+    color: white;
+    font-weight: 600;
+}
+
+.col-day.day-fully-staffed small {
+    color: rgba(255, 255, 255, 0.9);
 }
 
 /* JobTread action icons in day headers */
@@ -952,17 +955,26 @@ header p {
 /* Schedule Cells */
 .schedule-cell {
     border: 1px solid var(--border-gray);
-    padding: 6px;
+    padding: 4px;
     min-width: 70px;
-    min-height: 60px;
+    height: 80px;
+    max-height: 80px;
     vertical-align: top;
-    transition: background 0.2s ease;
+    transition: all 0.2s ease;
     position: relative;
+    overflow: hidden;
 }
 
 .schedule-cell.drag-over {
     background: #bbdefb !important;
     border-color: var(--primary-blue);
+}
+
+/* Selected cell (keyboard navigation) */
+.schedule-cell.cell-selected {
+    box-shadow: 0 0 0 3px var(--primary-blue);
+    border-color: var(--primary-blue);
+    z-index: 10;
 }
 
 /* Crew Copy Handle */
@@ -1016,6 +1028,50 @@ header p {
     50% { opacity: 0.7; }
 }
 
+/* Typeahead Dropdown */
+.typeahead-dropdown {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: white;
+    border: 2px solid var(--primary-blue);
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    z-index: 100;
+    max-height: 200px;
+    overflow-y: auto;
+    margin-top: 2px;
+}
+
+.typeahead-header {
+    padding: 6px 8px;
+    background: #f5f5f5;
+    border-bottom: 1px solid var(--border-gray);
+    font-size: 0.7em;
+    font-weight: 600;
+    color: #666;
+}
+
+.typeahead-item {
+    padding: 8px;
+    cursor: pointer;
+    font-size: 0.8em;
+    border-bottom: 1px solid #f0f0f0;
+    transition: background 0.2s ease;
+}
+
+.typeahead-item:hover,
+.typeahead-item.selected {
+    background: #e3f2fd;
+}
+
+.typeahead-role {
+    color: #666;
+    font-size: 0.9em;
+    margin-left: 4px;
+}
+
 /* Click-to-Assign Mode */
 .click-assign-mode {
     cursor: pointer;
@@ -1028,30 +1084,32 @@ header p {
 .cell-demand-row {
     display: flex;
     align-items: center;
-    gap: 4px;
-    margin-bottom: 4px;
+    gap: 3px;
+    margin-bottom: 3px;
 }
 
 .demand-input {
-    width: 40px;
-    padding: 2px 4px;
+    width: 32px;
+    padding: 2px;
     border: 1px solid var(--border-gray);
     border-radius: 3px;
-    font-size: 0.85em;
+    font-size: 0.8em;
     text-align: center;
 }
 
 .assigned-count {
-    font-size: 0.75em;
+    font-size: 0.7em;
     color: #666;
     margin-left: auto;
 }
 
 .cell-workers {
-    min-height: 30px;
     display: flex;
     flex-wrap: wrap;
     align-items: flex-start;
+    gap: 2px;
+    max-height: 52px;
+    overflow-y: auto;
 }
 
 /* Cell Status Colors */

--- a/js/app.js
+++ b/js/app.js
@@ -46,6 +46,14 @@ let viewMode = 'job'; // 'job' or 'crew' board
 let divisionFilter = 'commercial'; // 'commercial', 'residential', or 'both'
 let jobColors = {}; // Map of jobId to color for crew board
 
+// Keyboard navigation state
+let selectedCellJobId = null; // Currently selected cell's job ID
+let selectedCellDateKey = null; // Currently selected cell's date key
+let typeaheadBuffer = ''; // Buffer for typeahead search
+let typeaheadTimeout = null; // Timeout for clearing typeahead buffer
+let typeaheadResults = []; // Filtered workers from typeahead
+let typeaheadSelectedIndex = 0; // Selected index in typeahead results
+
 // Manpower tracking constants
 const ROLE_WEIGHTS = {
     'foreman': 1.3,      // 30% more productive (experienced, decision-maker)
@@ -345,18 +353,283 @@ function showJobMenu(jobId, dateKey) {
 }
 
 /**
- * Close any modal with ESC key
+ * Keyboard event handler for modals and navigation
  */
 document.addEventListener('keydown', function(e) {
+    // Close modals with ESC
     if (e.key === 'Escape') {
+        // First check if typeahead is showing
+        if (typeaheadBuffer) {
+            clearTypeahead();
+            return;
+        }
+        // Then check if cell is selected
+        if (selectedCellJobId !== null) {
+            deselectCell();
+            return;
+        }
+        // Finally close modals
         closeAddWorkerModal();
         closeAddJobModal();
         closeConfirmModal();
         closePromptModal();
         closeEditJobModal();
         closePrintModal();
+        return;
+    }
+
+    // Ignore keyboard navigation if modal is open
+    if (document.querySelector('.modal.active')) {
+        return;
+    }
+
+    // Handle keyboard navigation (arrow keys)
+    if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+        e.preventDefault();
+        handleArrowKey(e.key);
+        return;
+    }
+
+    // Handle Enter key (assign worker from typeahead or toggle selection)
+    if (e.key === 'Enter') {
+        e.preventDefault();
+        if (typeaheadResults.length > 0) {
+            assignWorkerFromTypeahead();
+        }
+        return;
+    }
+
+    // Handle Command/Ctrl + R (copy across row)
+    if ((e.metaKey || e.ctrlKey) && e.key === 'r') {
+        e.preventDefault();
+        copyAssignmentAcrossWeek();
+        return;
+    }
+
+    // Handle alphanumeric input for typeahead
+    if (selectedCellJobId !== null && e.key.length === 1 && /[a-zA-Z0-9 ]/.test(e.key)) {
+        e.preventDefault();
+        handleTypeahead(e.key);
+        return;
+    }
+
+    // Handle Backspace for typeahead
+    if (selectedCellJobId !== null && e.key === 'Backspace') {
+        e.preventDefault();
+        if (typeaheadBuffer) {
+            typeaheadBuffer = typeaheadBuffer.slice(0, -1);
+            updateTypeahead();
+        }
+        return;
     }
 });
+
+// ============================================================================
+// Keyboard Navigation Functions
+// ============================================================================
+
+/**
+ * Select a cell for keyboard navigation
+ */
+function selectCell(jobId, dateKey) {
+    selectedCellJobId = jobId;
+    selectedCellDateKey = dateKey;
+    renderSchedule();
+}
+
+/**
+ * Deselect the currently selected cell
+ */
+function deselectCell() {
+    selectedCellJobId = null;
+    selectedCellDateKey = null;
+    clearTypeahead();
+    renderSchedule();
+}
+
+/**
+ * Handle arrow key navigation
+ */
+function handleArrowKey(key) {
+    const activeJobs = jobs.filter(j => j.active);
+    if (activeJobs.length === 0) return;
+
+    const dates = getScheduleDates();
+
+    // If no cell selected, select the first cell
+    if (selectedCellJobId === null) {
+        selectCell(activeJobs[0].id, getDateKey(dates[0]));
+        return;
+    }
+
+    // Find current position
+    const jobIndex = activeJobs.findIndex(j => j.id === selectedCellJobId);
+    const dateIndex = dates.findIndex(d => getDateKey(d) === selectedCellDateKey);
+
+    if (jobIndex === -1 || dateIndex === -1) {
+        // Invalid state, reset
+        selectCell(activeJobs[0].id, getDateKey(dates[0]));
+        return;
+    }
+
+    let newJobIndex = jobIndex;
+    let newDateIndex = dateIndex;
+
+    switch (key) {
+        case 'ArrowUp':
+            newJobIndex = Math.max(0, jobIndex - 1);
+            break;
+        case 'ArrowDown':
+            newJobIndex = Math.min(activeJobs.length - 1, jobIndex + 1);
+            break;
+        case 'ArrowLeft':
+            newDateIndex = Math.max(0, dateIndex - 1);
+            break;
+        case 'ArrowRight':
+            newDateIndex = Math.min(dates.length - 1, dateIndex + 1);
+            break;
+    }
+
+    selectCell(activeJobs[newJobIndex].id, getDateKey(dates[newDateIndex]));
+
+    // Scroll selected cell into view
+    scrollCellIntoView(activeJobs[newJobIndex].id, getDateKey(dates[newDateIndex]));
+}
+
+/**
+ * Scroll selected cell into view
+ */
+function scrollCellIntoView(jobId, dateKey) {
+    setTimeout(() => {
+        const cell = document.querySelector(`.schedule-cell[data-job-id="${jobId}"][data-date-key="${dateKey}"]`);
+        if (cell) {
+            cell.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+        }
+    }, 50);
+}
+
+/**
+ * Handle typeahead input
+ */
+function handleTypeahead(char) {
+    typeaheadBuffer += char;
+    updateTypeahead();
+
+    // Reset timeout
+    if (typeaheadTimeout) clearTimeout(typeaheadTimeout);
+    typeaheadTimeout = setTimeout(() => {
+        clearTypeahead();
+    }, 3000); // Clear after 3 seconds of no typing
+}
+
+/**
+ * Update typeahead results
+ */
+function updateTypeahead() {
+    if (!typeaheadBuffer) {
+        typeaheadResults = [];
+        typeaheadSelectedIndex = 0;
+        renderSchedule();
+        return;
+    }
+
+    // Filter workers by name (case-insensitive)
+    const searchLower = typeaheadBuffer.toLowerCase();
+    typeaheadResults = workers.filter(w =>
+        w.name.toLowerCase().includes(searchLower)
+    );
+    typeaheadSelectedIndex = 0;
+
+    renderSchedule();
+}
+
+/**
+ * Clear typeahead state
+ */
+function clearTypeahead() {
+    typeaheadBuffer = '';
+    typeaheadResults = [];
+    typeaheadSelectedIndex = 0;
+    if (typeaheadTimeout) clearTimeout(typeaheadTimeout);
+    typeaheadTimeout = null;
+    renderSchedule();
+}
+
+/**
+ * Assign worker from typeahead selection
+ */
+function assignWorkerFromTypeahead() {
+    if (typeaheadResults.length === 0 || selectedCellJobId === null) return;
+
+    const worker = typeaheadResults[typeaheadSelectedIndex];
+    if (!worker) return;
+
+    // Assign the worker
+    const slotKey = `${selectedCellJobId}_${selectedCellDateKey}`;
+    const slot = dailySchedule[slotKey] || { demand: 0, assigned: [] };
+
+    // Check if already assigned
+    if (!slot.assigned.includes(worker.id)) {
+        slot.assigned.push(worker.id);
+        dailySchedule[slotKey] = slot;
+        saveData();
+    }
+
+    clearTypeahead();
+    renderSchedule();
+}
+
+/**
+ * Copy assignments across the entire week
+ */
+function copyAssignmentAcrossWeek() {
+    if (selectedCellJobId === null || selectedCellDateKey === null) return;
+
+    const slotKey = `${selectedCellJobId}_${selectedCellDateKey}`;
+    const sourceSlot = dailySchedule[slotKey];
+    if (!sourceSlot || !sourceSlot.assigned || sourceSlot.assigned.length === 0) {
+        return; // Nothing to copy
+    }
+
+    // Find which week this date belongs to
+    const dates = getScheduleDates();
+    const sourceDate = dates.find(d => getDateKey(d) === selectedCellDateKey);
+    if (!sourceDate) return;
+
+    const sourceDayOfWeek = sourceDate.getDay();
+
+    // Copy to all days in the 3-week view
+    dates.forEach(date => {
+        const dateKey = getDateKey(date);
+        if (dateKey === selectedCellDateKey) return; // Skip source
+
+        const targetSlotKey = `${selectedCellJobId}_${dateKey}`;
+        const targetSlot = dailySchedule[targetSlotKey] || { demand: 0, assigned: [] };
+
+        // Copy the workers
+        targetSlot.assigned = [...sourceSlot.assigned];
+        dailySchedule[targetSlotKey] = targetSlot;
+    });
+
+    saveData();
+    renderSchedule();
+}
+
+/**
+ * Get schedule dates (helper)
+ */
+function getScheduleDates() {
+    const dates = [];
+    for (let week = 0; week < 3; week++) {
+        const weekStart = getWeekMonday(scheduleWeekOffset + week);
+        for (let day = 0; day < 6; day++) {
+            const date = new Date(weekStart);
+            date.setDate(weekStart.getDate() + day);
+            dates.push(date);
+        }
+    }
+    return dates;
+}
 
 // ============================================================================
 // Form Event Handlers
@@ -1084,13 +1357,29 @@ function renderScheduleGrid(dates) {
     html += `</tr><tr class="day-headers">
                 <th class="col-job"></th>`;
 
-    // Day headers (18 columns = 3 weeks × 6 days) with dates - clickable for filtering
+    // Day headers (18 columns = 3 weeks × 6 days) with dates - green when fully staffed
     dates.forEach(date => {
         const dayName = dayNames[date.getDay() === 0 ? 6 : date.getDay() - 1];
         const dateStr = `${date.getMonth() + 1}/${date.getDate()}`;
         const dateKey = getDateKey(date);
         const activeClass = activeDateKey === dateKey ? 'day-active' : '';
-        html += `<th class="col-day ${activeClass}" onclick="activateDay('${dateKey}', this)" style="cursor: pointer;" title="Click to filter available workers">
+
+        // Check if this day is fully staffed
+        let totalNeeded = 0;
+        const assignedWorkerIds = new Set();
+        Object.keys(dailySchedule).forEach(key => {
+            if (key.endsWith(`_${dateKey}`)) {
+                const slot = dailySchedule[key];
+                totalNeeded += parseInt(slot.demand) || 0;
+                if (slot.assigned) {
+                    slot.assigned.forEach(wId => assignedWorkerIds.add(wId));
+                }
+            }
+        });
+        const isFullyStaffed = totalNeeded > 0 && assignedWorkerIds.size >= totalNeeded;
+        const fullyStaffedClass = isFullyStaffed ? 'day-fully-staffed' : '';
+
+        html += `<th class="col-day ${activeClass} ${fullyStaffedClass}" onclick="activateDay('${dateKey}', this)" style="cursor: pointer;" title="Click to filter available workers">
             ${dayName}<br><small>${dateStr}</small>
             <div class="day-jobtread-actions">
                 <span class="jobtread-icon jobtread-push" onclick="event.stopPropagation(); pushDayToJobTread('${dateKey}')" title="Push to JobTread">📤</span>
@@ -1252,14 +1541,18 @@ function renderScheduleGrid(dates) {
 
                 const assignedWorkers = assigned.map(id => workers.find(w => w.id === id)).filter(Boolean);
 
-                html += `<td class="schedule-cell ${statusClass} ${selectedWorkerId ? 'click-assign-mode' : ''}"
+                // Check if this cell is selected
+                const isSelected = selectedCellJobId === job.id && selectedCellDateKey === dateKey;
+                const selectedClass = isSelected ? 'cell-selected' : '';
+
+                html += `<td class="schedule-cell ${statusClass} ${selectedClass} ${selectedWorkerId ? 'click-assign-mode' : ''}"
                              data-job-id="${job.id}"
                              data-date-key="${dateKey}"
                              ondragover="handleCellDragOver(event, ${job.id}, '${dateKey}')"
                              ondragleave="this.classList.remove('drag-over')"
                              ondrop="handleCellDrop(event, ${job.id}, '${dateKey}')"
-                             onclick="clickAssignWorker(${job.id}, '${dateKey}')"
-                             title="${selectedWorkerId ? 'Click to assign selected worker' : 'Drag worker here or click worker first'}">
+                             onclick="handleCellClick(${job.id}, '${dateKey}')"
+                             title="Click to select, type to search workers, Enter to assign">
                     <div class="cell-demand-row">
                         <input type="number" class="demand-input" value="${demand}" min="0" max="9"
                                onchange="setDemand(${job.id}, '${dateKey}', this.value)"
@@ -1273,9 +1566,9 @@ function renderScheduleGrid(dates) {
                                 <div class="worker-chip-mini worker-chip-${w.role}"
                                      draggable="true"
                                      ondragstart="dragWorkerStart(event, ${w.id}, ${job.id}, '${dateKey}')"
-                                     title="${w.name}">
+                                     onclick="removeScheduleWorker(${job.id}, '${dateKey}', ${w.id}); event.stopPropagation();"
+                                     title="${w.name} (click to remove)">
                                     <span class="chip-name-mini">${w.name.split(' ')[0]}</span>
-                                    <button class="chip-remove" onclick="removeScheduleWorker(${job.id}, '${dateKey}', ${w.id}); event.stopPropagation()">×</button>
                                 </div>
                             `).join('')}
                         </div>
@@ -1286,6 +1579,17 @@ function renderScheduleGrid(dates) {
                                  ondragend="endCrewCopy(event)"
                                  title="Drag to copy crew across days ⇒">
                                 ⇒
+                            </div>
+                        ` : ''}
+                        ${isSelected && typeaheadResults.length > 0 ? `
+                            <div class="typeahead-dropdown">
+                                <div class="typeahead-header">Search: "${typeaheadBuffer}"</div>
+                                ${typeaheadResults.map((w, idx) => `
+                                    <div class="typeahead-item ${idx === typeaheadSelectedIndex ? 'selected' : ''}"
+                                         onclick="assignWorkerFromTypeahead(); event.stopPropagation();">
+                                        ${w.name} <span class="typeahead-role">(${w.role})</span>
+                                    </div>
+                                `).join('')}
                             </div>
                         ` : ''}
                     ` : ''}
@@ -1917,6 +2221,26 @@ function toggleWorkerSelection(workerId) {
         selectedWorkerId = workerId;
     }
     renderSchedule();
+}
+
+/**
+ * Handle cell click for keyboard navigation
+ */
+function handleCellClick(jobId, dateKey) {
+    // If there's a selected worker (old click-to-assign mode), use that
+    if (selectedWorkerId) {
+        clickAssignWorker(jobId, dateKey);
+        return;
+    }
+
+    // Otherwise, select/deselect the cell for keyboard navigation
+    if (selectedCellJobId === jobId && selectedCellDateKey === dateKey) {
+        // Clicking same cell - deselect
+        deselectCell();
+    } else {
+        // Select this cell
+        selectCell(jobId, dateKey);
+    }
 }
 
 /**


### PR DESCRIPTION
- Implemented full keyboard navigation (arrow keys to move between cells)
- Added typeahead search: type worker names in selected cell, Enter to assign
- Command+R copies assignments across all days in 3-week view
- Removed X buttons: click worker chips directly to remove
- Standardized cell heights (80px) for consistent grid appearance
- Tightened spacing throughout (padding, gaps, input sizes)
- Day headers turn green when fully staffed (visual indicator)
- Selected cell highlighted with blue border for clarity
- Typeahead dropdown shows filtered workers in real-time
- ESC key deselects cell or clears typeahead

Keyboard shortcuts:
- Arrow keys: Navigate cells
- Type: Search workers
- Enter: Assign selected worker
- Cmd/Ctrl+R: Copy assignments across week
- ESC: Deselect/Cancel

https://claude.ai/code/session_01BPeAQAFYCgSgLh8dKSanjx