### PR TITLE
Fix Enter key not assigning worker from typeahead

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -800,12 +800,19 @@ function assignWorkerFromTypeahead() {
 
     // Assign the worker to primary cell
     const slotKey = `${primaryCell.jobId}_${primaryCell.dateKey}`;
-    const slot = dailySchedule[slotKey] || { demand: 0, assigned: [] };
+    if (!dailySchedule[slotKey]) {
+        dailySchedule[slotKey] = { demand: 0, assigned: [] };
+    }
+    const slot = dailySchedule[slotKey];
+
+    // Ensure assigned array exists
+    if (!Array.isArray(slot.assigned)) {
+        slot.assigned = [];
+    }
 
     // Check if already assigned
     if (!slot.assigned.includes(worker.id)) {
         slot.assigned.push(worker.id);
-        dailySchedule[slotKey] = slot;
         saveData();
     }
 


### PR DESCRIPTION
Fixed issue where pressing Enter in typeahead dropdown didn't assign worker:

Changes:
- Ensure dailySchedule slot is properly initialized before assigning
- Explicitly check and initialize assigned array if needed
- More robust handling of slot creation and assignment

The issue was that the slot assignment logic could fail if the slot existed but didn't have a proper assigned array structure.

Now works as expected:
1. Type to search workers
2. Use Up/Down to select from dropdown
3. Press Enter to assign selected worker
4. Worker is added to the cell

https://claude.ai/code/session_01BPeAQAFYCgSgLh8dKSanjx