### PR TITLE
Fix typeahead dropdown visibility and timeout issues

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1042,10 +1042,16 @@ header p {
     border: 2px solid var(--primary-blue);
     border-radius: 4px;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-    z-index: 100;
+    z-index: 10000;
     max-height: 200px;
     overflow-y: auto;
     margin-top: 2px;
+}
+
+/* Ensure cell with dropdown has high z-index and can overflow */
+.schedule-cell:has(.typeahead-dropdown) {
+    z-index: 10001 !important;
+    position: relative;
 }
 
 .typeahead-header {

--- a/js/app.js
+++ b/js/app.js
@@ -727,11 +727,7 @@ function handleTypeahead(char) {
     typeaheadBuffer += char;
     updateTypeahead();
 
-    // Reset timeout
-    if (typeaheadTimeout) clearTimeout(typeaheadTimeout);
-    typeaheadTimeout = setTimeout(() => {
-        clearTypeahead();
-    }, 3000); // Clear after 3 seconds of no typing
+    // No auto-clear timeout - user must press Escape to close
 }
 
 /**


### PR DESCRIPTION
Fixed three issues with typeahead dropdown:

1. Dropdown falling under table at bottom:
   - Increased z-index to 10000 (above sticky headers)
   - Added special z-index boost for cells containing dropdown
   - Dropdown now appears above all table elements

2. Removed 3 second auto-clear timeout:
   - Dropdown stays open until user takes action
   - No more frustrating auto-close while searching
   - User has full control over when to close

3. Escape key to close (verified working):
   - Press Escape to close typeahead dropdown
   - Clears search and returns to normal cell selection
   - Priority: Escape closes typeahead first, then deselects cell

How typeahead works now:
1. Type to search - dropdown appears
2. Use Up/Down arrows to select worker
3. Press Enter to assign
4. Press Escape to cancel/close dropdown
5. Dropdown stays open until you close it or assign

No more issues with:
- Dropdown cut off at bottom of page
- Dropdown disappearing after 3 seconds
- Unable to close dropdown

https://claude.ai/code/session_01BPeAQAFYCgSgLh8dKSanjx